### PR TITLE
change % to decimal values

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,5 +24,5 @@ body {
 
 button:hover {
   cursor: pointer;
-  opacity: 50%;
+  opacity: 0.5;
 }

--- a/src/components/pages/contact-page.css
+++ b/src/components/pages/contact-page.css
@@ -18,5 +18,5 @@
 }
 
 .contact-button:hover {
-  opacity: 50%;
+  opacity: 0.5;
 }


### PR DESCRIPTION
A known bug when using % instead of decimal values: https://stackoverflow.com/questions/58853844/the-opacity-value-was-changed-to-1-after-building-the-reacjs-project

Now this should make it so that it builds the app without turning the 50% opacity to 1% opacity