### PR TITLE
use absolute values for opacity

### DIFF
--- a/src/components/graphs/SimpleBarChartGDP.css
+++ b/src/components/graphs/SimpleBarChartGDP.css
@@ -15,18 +15,18 @@
 .bar {
   fill: black;
   width: 2px;
-  opacity: 100%;
+  opacity: 1;
 }
 
 .bar:hover {
-  opacity: 0%;
+  opacity: 0;
 }
 
 .tooltip {
   width: 5em;
   height: 1em;
   background-color: white;
-  opacity: 0%;
+  opacity: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/graphs/SimpleBarChartGDP.js
+++ b/src/components/graphs/SimpleBarChartGDP.js
@@ -142,7 +142,7 @@ for (let i=0; i<dataset.data.length; i++){
           tooltip
             .transition()
             .duration(0)
-            .style("opacity", "100%")
+            .style("opacity", "1")
             .style("left", barID * 3 + "px")
             .style("top", "250px")
 
@@ -153,7 +153,7 @@ for (let i=0; i<dataset.data.length; i++){
       d3.select(".simple-bar-chart")
         .selectAll(".bar")
         .on("mouseout", (event) => {
-          tooltip.style("opacity", "0%");
+          tooltip.style("opacity", "0");
         });
 
       //   Add bottom text


### PR DESCRIPTION
MZ browser interprets 100% as 1% opacity, so safer to use absolute values here